### PR TITLE
fix: fix get /favicon.ico problem when custom domain contains /* path in routerConfigs

### DIFF
--- a/src/lib/invoke/http-support.ts
+++ b/src/lib/invoke/http-support.ts
@@ -68,15 +68,20 @@ export async function registerSingleHttpTrigger(creds: ICredentials, region: str
   }
   app.use(setCORSHeaders);
   app.use(router);
-
   for (let method of httpMethods) {
     router[method.toLowerCase()](endpointForRoute, async (req, res) => {
+
       if (req.get('Upgrade') === 'websocket') {
         res.status(403).send('websocket not support');
         return;
       }
+      // Avoid get /favicon.ico, refer to: https://stackoverflow.com/questions/35408729/express-js-prevent-get-favicon-ico
+      if (_.isEqual(req.path, '/favicon.ico')) {
+        logger.debug(`Response '204 No Content' status when request path is: /favicon.ico`);
+        res.status(204).end();
+        return;
+      }
 
-      // @ts-ignore
       await httpInvoke.invoke(req, res);
     });
   }


### PR DESCRIPTION
### Fix

1. 当自定义域名下的 routerConfigs 中包含 path:/* 时，执行 s start ${domain} 后再访问 url，会出现两次请求，第一次是预期的，第二次是 GET /favicon.ico 请求，此时需要屏蔽第二次请求