### PR TITLE
fix: fix show localRoot:${buildPath} in .vscode/launch.json

### DIFF
--- a/src/lib/invoke/event-start.ts
+++ b/src/lib/invoke/event-start.ts
@@ -59,7 +59,6 @@ export default class EventStart extends Invoke {
       since: (new Date().getTime() / 1000)
     });
     console.log('Function container started successful.');
-    // await this.showDebugIdeTips();
     await this.setDebugIdeConfig();
   }
 }

--- a/src/lib/invoke/http-invoke.ts
+++ b/src/lib/invoke/http-invoke.ts
@@ -151,7 +151,6 @@ export default class HttpInvoke extends Invoke {
   async initAndStartRunner() {
     await this.init();
     await this._startRunner();
-    // await this.showDebugIdeTips();
     await this.setDebugIdeConfig();
   }
 

--- a/src/lib/invoke/invoke.ts
+++ b/src/lib/invoke/invoke.ts
@@ -97,7 +97,6 @@ export default class Invoke {
     }
 
     await this.beforeInvoke();
-    // await this.showDebugIdeTips();
     await this.setDebugIdeConfig();
     // @ts-ignore
     await this.doInvoke(req, res);
@@ -154,24 +153,13 @@ export default class Invoke {
 
   }
 
-  async showDebugIdeTips() {
-    if (this.debugPort && this.debugIde) {
-      // not show tips if debugIde is null
-      if (this.debugIde.toLowerCase() === 'vscode') {
-        await docker.showDebugIdeTipsForVscode(this.serviceName, this.functionName, this.runtime, this.codeMount.Source, this.debugPort);
-      } else if (this.debugIde.toLowerCase() === 'pycharm') {
-        await docker.showDebugIdeTipsForPycharm(this.codeMount.Source, this.debugPort);
-      }
-    }
-  }
-
   async setDebugIdeConfig() {
     if (this.debugPort && this.debugIde) {
       if (this.debugIde.toLowerCase() === 'vscode') {
         // try to write .vscode/config.json
         await writeDebugIdeConfigForVscode(this.baseDir, this.serviceName, this.functionName, this.runtime, this.functionConfig?.originalCodeUri ? path.join(this.baseDir, this.functionConfig.originalCodeUri) : null, this.debugPort);
       } else if (this.debugIde.toLowerCase() === 'pycharm') {
-        await docker.showDebugIdeTipsForPycharm(this.codeMount.Source, this.debugPort);
+        await docker.showDebugIdeTipsForPycharm(this.functionConfig?.originalCodeUri ? path.join(this.baseDir, this.functionConfig.originalCodeUri) : null, this.debugPort);
       }
     }
   }


### PR DESCRIPTION
### Fix 

1. pycharm 断点调试模式下，将目标代码路径由 build 路径更改为源代码路径