### PR TITLE
fix: add encoding: null to request options when custom-container runtime

### DIFF
--- a/src/lib/invoke/http.ts
+++ b/src/lib/invoke/http.ts
@@ -308,7 +308,8 @@ export function generateInitRequestOpts(req, port, fcHeaders) {
     headers: fcHeaders,
     uri: `http://localhost:${port}/initialize`,
     resolveWithFullResponse: true,
-    qs: req.query || {}
+    qs: req.query || {},
+    encoding: null
   };
   return opts;
 }
@@ -318,7 +319,8 @@ export function generateInvokeRequestOpts(port, fcReqHeaders, event) {
     method: 'POST',
     headers: fcReqHeaders,
     uri: `http://localhost:${port}/invoke`,
-    resolveWithFullResponse: true
+    resolveWithFullResponse: true,
+    encoding: null,
   };
   if (event.toString('utf8') !== '') {
     opts.body = event;
@@ -335,7 +337,8 @@ export function generateRequestOpts(req, port, fcReqHeaders, event) {
     headers: fcReqHeaders,
     uri: `http://localhost:${port}${req.originalUrl}`,
     resolveWithFullResponse: true,
-    qs: req.query
+    qs: req.query,
+    encoding: null,
   };
   if (event.toString('utf8') !== '') {
     opts.body = event;


### PR DESCRIPTION
### Fix

1. custom-container 情况下，在 request option 中增加 encoding: null 参数，避免对响应中的 body 进行不必要的编码